### PR TITLE
added optional chaining for matches in buildErrorStackFrames

### DIFF
--- a/sentry/sentry.js
+++ b/sentry/sentry.js
@@ -49,8 +49,8 @@ module.exports = function(RED) {
 	**/
 	function buildErrorStackFrames(error_message, node_id){
 		let matches = error_message.match(/line (\d+), col (\d+)/mi);
-		let line = matches[1] || 0;
-		let pos = matches[2] || 0;
+		let line = matches?.[1] || 0;
+		let pos = matches?.[2] || 0;
 		
 		const node_info = getNodeDetails(node_id);
 		


### PR DESCRIPTION
hey, `matches` is nullable, so you have to add optional chaining before accessing the index. otherwise the following type error occurs `TypeError: Cannot read properties of null (reading '1')`

awesome node btw, thanks a lot 