### PR TITLE
add: send errors of the node to sentry

### DIFF
--- a/sentry/sentry.js
+++ b/sentry/sentry.js
@@ -150,6 +150,7 @@ module.exports = function(RED) {
 					errorSent = true;//sent
 				}
 			}catch(err){
+				Sentry.captureException(err)
 				node.error(err);
 			}
 			msg.payload = {sent:errorSent};


### PR DESCRIPTION
Since we already have a sentry connection and want to capture errors,
let's also capture contrib-node errors there for debugging and reporting
purposes.