### PR TITLE
feat: ENVIRONMENT variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ the node will search for `msg.sentry` if found, any supported config will be set
 
 *   user: {id, username, email, ip_address}
 
+**Supported `ENVIRONMENT` variable**
+
+the node will use the `ENVIRONMENT` variable found in your `.env` file. Note: The property `Environment` takes precedence over this variable.
+
 **How it works?**
 
 if `msg` object includes errors `msg.error` it will be used and sent to sentry, if also contains `msg._error` it will be added as breadcrumb for the error sent.

--- a/sentry/sentry.js
+++ b/sentry/sentry.js
@@ -110,11 +110,12 @@ module.exports = function(RED) {
 	function SentryNode(config) {	
 		RED.nodes.createNode(this, config);
 		var node = this;
+		var ENVIRONMENT = RED.util.getSetting(node, 'ENVIRONMENT')
 		
 		/**
 		* init the sentry only on deployment
 		*/
-		Sentry.init({ dsn: config.dsn, environment: config.environment || 'debug' });
+		Sentry.init({ dsn: config.dsn, environment: config.environment || ENVIRONMENT || 'debug' });
 		
 		node.on('input', function(msg, send, done) {
 			


### PR DESCRIPTION
**Why**

Closes #4 

This is useful if you want to run Node Red in multiple environments and don't want to hard code the property variable `Environment` into your flow. Instead you can set the `ENVIRONMENT` variable in your `.env` file like so:

```
ENVIRONMENT=staging
```
